### PR TITLE
Fix misleading comment in ADAM task.

### DIFF
--- a/homework01/homework_modules.ipynb
+++ b/homework01/homework_modules.ipynb
@@ -957,7 +957,7 @@
     "            # update `current_var_first_moment`, `var_second_moment` and `current_var` values\n",
     "            #np.add(... , out=var_first_moment)\n",
     "            #np.add(... , out=var_second_moment)\n",
-    "            #current_grad -= ...\n",
+    "            #current_var -= ...\n",
     "            \n",
     "            # small checks that you've updated the state; use np.add for rewriting np.arrays values\n",
     "            assert var_first_moment is state['m'].get(var_index)\n",


### PR DESCRIPTION
There are a wrong comment in ADAM task,
`#current_grad -= ...` comment should be replaced with `#current_var -= ...`